### PR TITLE
Fix the remote repository URLs

### DIFF
--- a/README-build.html
+++ b/README-build.html
@@ -12,26 +12,25 @@ the 3D packages</span></h3>
  style="font-weight: bold;"></span></span><span
  style="font-weight: bold; text-decoration: underline;"> </span></p>
 <p>To
-build the 3D packages, you must checkout the following three
-svn
+build the 3D packages, you must clone the following three
 repositories:<br>
 </p>
 <ul>
-  <li><a href="http://j3d-core.dev.java.net/">j3d-core</a></li>
-  <li><a href="http://j3d-core-utils.dev.java.net/">j3d-core-utils</a></li>
-  <li><a href="http://vecmath.dev.java.net/">vecmath</a></li>
+  <li><a href="https://github.com/hharrison/java3d-core/">j3d-core</a></li>
+  <li><a href="https://github.com/hharrison/java3d-utils/">j3dutils</a></li>
+  <li><a href="https://github.com/hharrison/vecmath/">vecmath</a></li>
 </ul>
 <p>These three top-level directories must be named exactly as
 shown above and they must be sibling directories. To ensure this, run
-the svn checkout command for each of the respositories from the same
+the git clone command for each of the respositories from the same
 parent
 directory. For example:<br>
 </p>
 <ul>
   <code>cd &lt;j3d-root-dir&gt;</code><br>
-  <code>svn checkout https://vecmath.dev.java.net/svn/vecmath/branches/dev-1_6 vecmath</code><br>
-  <code>svn checkout https://j3d-core.dev.java.net/svn/j3d-core/branches/dev-1_6 j3d-core</code><br>
-  <code>svn checkout https://j3d-core-utils.dev.java.net/svn/j3d-core-utils/branches/dev-1_6 j3d-core-utils</code>
+  <code>git clone git://github.com/hharrison/vecmath</code><br>
+  <code>git clone git://github.com/hharrison/java3d-core j3d-core</code><br>
+  <code>git clone git://github.com/hharrison/java3d-utils j3dutils</code>
 </ul>
 <p>NOTE: you must first build the javax.vecmath package before building
 the javax.media.j3d and com.sun.j3d.* packages. See the <a


### PR DESCRIPTION
In a recent [online discussion](https://groups.google.com/d/msg/fiji-devel/DdACGtGX3VQ/3XOYjazjB1cJ), a user was confused by the fact that the `README-build.html` still lists the old canonical Java3D SVN repositories, rather than those of this fork on GitHub. So this PR updates the repository URLs accordingly.

Unfortunately, I do not have time to fully update the build instructions to completely work: it looks like jogl is needed also in a sibling or parent directory. What would be really sweet would be for the build to be Maven-based instead, but I am not sure how involved it would be to update the build system. It would definitely help this fork gain steam over the original (now thoroughly outdated) Java3D project, though.

At minimum, a `README.md` would be nice explaining how the core developers do actually go about building this and related projects. Maybe I missed it somewhere...?