### PR TITLE
Eliminate circular dependency between core & utils

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -84,7 +84,7 @@
 
     <copy todir="${class.dir}">
       <fileset dir="${src.dir}"          includes="**/*.properties"/>
-      <fileset dir="${j3dtools.src.dir}/classes/share" includes="**/*.properties"/>
+      <fileset dir="${j3dtools.src.dir}/classes/share" includes="META-INF/** **/*.properties"/>
     </copy>
   </target>
   
@@ -118,7 +118,7 @@
         <attribute name="Extension-Name"            value="javax.media.j3d"/>
         <attribute name="Implementation-Vendor-Id"  value="${build.impl.vendor.id}"/>
       </manifest>
-      <fileset dir="${class.dir}" includes="com/**/*"/>
+      <fileset dir="${class.dir}" includes="META-INF/** com/**/*"/>
     </jar>
     
     <zip destfile="${build.dir}/jars/j3dcore-src.zip">

--- a/src/javax/media/j3d/Font3D.java
+++ b/src/javax/media/j3d/Font3D.java
@@ -461,7 +461,7 @@ private static class IntVector {
 
 	    int[] contourCounts = new int[1];
 	    int currCoordIndex = 0, vertOffset = 0;
-		ArrayList<GeometryArray> triangData = new ArrayList<GeometryArray>();
+	    ArrayList<GeometryArray> triangData = new ArrayList<GeometryArray>();
 
 	    Point3f q1 = new Point3f(), q2 = new Point3f(), q3 = new Point3f();
 	    Vector3f n1 = new Vector3f(), n2 = new Vector3f();

--- a/src/javax/media/j3d/Font3D.java
+++ b/src/javax/media/j3d/Font3D.java
@@ -466,12 +466,14 @@ private static class IntVector {
 	    Point3f q1 = new Point3f(), q2 = new Point3f(), q3 = new Point3f();
 	    Vector3f n1 = new Vector3f(), n2 = new Vector3f();
 	    numPoints = 0;
+	    for (i = 0; i < islandCounts.length; i++) {
+	      numPoints += outVerts[i].length;
+	    }
 	    //Now loop thru each island, calling triangulator once per island.
 	    //Combine triangle data for all islands together in one object.
 		NormalGenerator ng = new NormalGenerator();
 		for (i = 0; i < islandCounts.length; i++) {
 			contourCounts[0] = islandCounts[i].length;
-			numPoints += outVerts[i].length;
 			GeometryInfo gi = new GeometryInfo(GeometryInfo.POLYGON_ARRAY);
 			gi.setCoordinates(outVerts[i]);
 			gi.setStripCounts(islandCounts[i]);

--- a/src/javax/media/j3d/Font3D.java
+++ b/src/javax/media/j3d/Font3D.java
@@ -460,7 +460,6 @@ private static class IntVector {
 	    vertices = null;
 
 	    int[] contourCounts = new int[1];
-	    int currCoordIndex = 0, vertOffset = 0;
 	    ArrayList<GeometryArray> triangData = new ArrayList<GeometryArray>();
 
 	    Point3f q1 = new Point3f(), q2 = new Point3f(), q3 = new Point3f();
@@ -471,6 +470,7 @@ private static class IntVector {
 	    }
 	    //Now loop thru each island, calling triangulator once per island.
 	    //Combine triangle data for all islands together in one object.
+	    int vertOffset = 0;
 		NormalGenerator ng = new NormalGenerator();
 		for (i = 0; i < islandCounts.length; i++) {
 			contourCounts[0] = islandCounts[i].length;
@@ -510,7 +510,7 @@ private static class IntVector {
 	    // last known non-degenerate normal
 	    Vector3f goodNormal = new Vector3f();
 
-
+	    int currCoordIndex = 0;
 	    for (j=0;j < islandCounts.length;j++) {
 			GeometryArray ga = triangData.get(j);
 		vertOffset = ga.getVertexCount();

--- a/src/javax/media/j3d/Font3D.java
+++ b/src/javax/media/j3d/Font3D.java
@@ -468,23 +468,8 @@ private static class IntVector {
 	    for (i = 0; i < islandCounts.length; i++) {
 	      numPoints += outVerts[i].length;
 	    }
-	    //Now loop thru each island, calling triangulator once per island.
-	    //Combine triangle data for all islands together in one object.
-	    int vertOffset = 0;
-		NormalGenerator ng = new NormalGenerator();
-		for (i = 0; i < islandCounts.length; i++) {
-			contourCounts[0] = islandCounts[i].length;
-			GeometryInfo gi = new GeometryInfo(GeometryInfo.POLYGON_ARRAY);
-			gi.setCoordinates(outVerts[i]);
-			gi.setStripCounts(islandCounts[i]);
-			gi.setContourCounts(contourCounts);
-			ng.generateNormals(gi);
-
-			GeometryArray ga = gi.getGeometryArray(false, false, false);
-			vertOffset += ga.getVertexCount();
-
-			triangData.add(ga);
-		}
+	    int vertOffset =
+	      triangulateIslands(islandCounts, outVerts, contourCounts, triangData);
 	    // Multiply by 2 since we create 2 faces of the font
 	    // Second term is for side-faces along depth of the font
 	    if (fontExtrusion == null)
@@ -959,6 +944,31 @@ private static class IntVector {
 	return geo;
     }
 
+	/**
+	 * Loops through each island, calling triangulator once per island. Combines
+	 * triangle data for all islands together in one object.
+	 */
+	private int triangulateIslands(final int[][] islandCounts,
+		final Point3f[][] outVerts, final int[] contourCounts,
+		final ArrayList<GeometryArray> triangData)
+	{
+		int vertOffset = 0;
+		NormalGenerator ng = new NormalGenerator();
+		for (int i = 0; i < islandCounts.length; i++) {
+			contourCounts[0] = islandCounts[i].length;
+			GeometryInfo gi = new GeometryInfo(GeometryInfo.POLYGON_ARRAY);
+			gi.setCoordinates(outVerts[i]);
+			gi.setStripCounts(islandCounts[i]);
+			gi.setContourCounts(contourCounts);
+			ng.generateNormals(gi);
+
+			GeometryArray ga = gi.getGeometryArray(false, false, false);
+			vertOffset += ga.getVertexCount();
+
+			triangData.add(ga);
+		}
+		return vertOffset;
+	}
 
     static boolean getNormal(Point3f p1, Point3f p2, Point3f p3, Vector3f normal) {
 	Vector3f v1 = new Vector3f();

--- a/src/javax/media/j3d/GeometryService.java
+++ b/src/javax/media/j3d/GeometryService.java
@@ -1,0 +1,41 @@
+
+package javax.media.j3d;
+
+import java.util.ArrayList;
+
+import javax.vecmath.Point3f;
+
+/**
+ * A service interface for certain geometric operations that are not available
+ * in core Java 3D.
+ * <p>
+ * In particular, the {@code j3d-core-utils} project provides additional
+ * functionality under a different license, which is needed in some
+ * circumstances by core Java 3D. Thus, historically, these two projects have
+ * been co-dependent. This interface breaks the circular dependency by using
+ * Java's service discovery mechanism: if {@code j3d-core-utils} is present on
+ * the classpath, its {@code GeometryServiceImpl} will provide the functionality
+ * defined here. Or if not (i.e., no suitable {@code GeometryService}
+ * implementation can be discovered and instantiated}), then the Java3D core
+ * will fail as gracefully as possible.
+ * </p>
+ * 
+ * @author Curtis Rueden
+ * @see Font3D#triangulateGlyphs
+ */
+public interface GeometryService {
+
+	/**
+	 * Loops through each island, calling triangulator once per island. Combines
+	 * triangle data for all islands together in one object.
+	 * 
+	 * @param islandCounts TODO
+	 * @param outVerts TODO
+	 * @param contourCounts TODO
+	 * @param triangData TODO
+	 * @return total vertex count of the combined array
+	 */
+	int triangulateIslands(int[][] islandCounts, Point3f[][] outVerts,
+		int[] contourCounts, ArrayList<GeometryArray> triangData);
+
+}


### PR DESCRIPTION
The class `javax.media.j3d.Font3D` of `j3d-core` imported classes from package `com.sun.j3d.utils.geometry`, which is part of `j3d-core-utils`. And the `j3d-core-utils` project imports many classes from `j3d-core`. This creates a circular dependency between artifacts.

This branch updates `java3d-core` to no longer depend on `java3d-utils` directly, but instead provide a `ServiceLoader`-based extensibility mechanism. That way, the `java3d-utils` component depends on `java3d-core`, but not vice versa.

Closes #17.

See also hharrison/java3d-utils#2.