### PR TITLE
Fix Hidpi usage

### DIFF
--- a/src/javax/media/j3d/Canvas3D.java
+++ b/src/javax/media/j3d/Canvas3D.java
@@ -26,7 +26,18 @@
 
 package javax.media.j3d;
 
-import java.awt.*;
+import java.awt.AWTEvent;
+import java.awt.Canvas;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.GraphicsConfiguration;
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
+import java.awt.IllegalComponentStateException;
+import java.awt.Point;
+import java.awt.Window;
 import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;

--- a/src/javax/media/j3d/Canvas3D.java
+++ b/src/javax/media/j3d/Canvas3D.java
@@ -32,6 +32,7 @@ import java.awt.Container;
 import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.Graphics;
+import java.awt.Graphics2D;
 import java.awt.GraphicsConfiguration;
 import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
@@ -821,6 +822,8 @@ ArrayList<Integer> textureIdResourceFreeList = new ArrayList<Integer>();
     // CanvasViewEventCatcher.
     Point newPosition = new Point();
     Dimension newSize = new Dimension();
+    double xscale = 1.0;
+    double yscale = 1.0;
 
 // Remember OGL context resources to free
 // before context is destroy.
@@ -1233,7 +1236,9 @@ ArrayList<TextureRetained> textureIDResourceTable = new ArrayList<TextureRetaine
 
 	    try {
 	        Dimension scaledSize = getSize();
-	        newSize = new Dimension((int)(scaledSize.getWidth()*t.getScaleX()), (int)(scaledSize.getHeight()*t.getScaleY()));
+	        xscale = t.getScaleX();
+	        yscale = t.getScaleY();
+	        newSize = new Dimension((int)(scaledSize.getWidth()*xscale), (int)(scaledSize.getHeight()*yscale));
 		    newPosition = getLocationOnScreen();
 	    } catch (IllegalComponentStateException e) {
 		return;

--- a/src/javax/media/j3d/Canvas3D.java
+++ b/src/javax/media/j3d/Canvas3D.java
@@ -26,18 +26,8 @@
 
 package javax.media.j3d;
 
-import java.awt.AWTEvent;
-import java.awt.Canvas;
-import java.awt.Container;
-import java.awt.Dimension;
-import java.awt.Frame;
-import java.awt.Graphics;
-import java.awt.GraphicsConfiguration;
-import java.awt.GraphicsDevice;
-import java.awt.GraphicsEnvironment;
-import java.awt.IllegalComponentStateException;
-import java.awt.Point;
-import java.awt.Window;
+import java.awt.*;
+import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Hashtable;
@@ -1227,9 +1217,13 @@ ArrayList<TextureRetained> textureIDResourceTable = new ArrayList<TextureRetaine
 	if (!firstPaintCalled && added && validCanvas &&
 	    validGraphicsMode()) {
 
+        final Graphics2D g2d = (Graphics2D) g;
+        final AffineTransform t = g2d.getTransform();
+
 	    try {
-		newSize = getSize();
-		newPosition = getLocationOnScreen();
+	        Dimension scaledSize = getSize();
+	        newSize = new Dimension((int)(scaledSize.getWidth()*t.getScaleX()), (int)(scaledSize.getHeight()*t.getScaleY()));
+		    newPosition = getLocationOnScreen();
 	    } catch (IllegalComponentStateException e) {
 		return;
 	    }

--- a/src/javax/media/j3d/CanvasViewEventCatcher.java
+++ b/src/javax/media/j3d/CanvasViewEventCatcher.java
@@ -26,6 +26,7 @@
 
 package javax.media.j3d;
 
+import java.awt.Dimension;
 import java.awt.IllegalComponentStateException;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
@@ -65,7 +66,8 @@ class CanvasViewEventCatcher extends ComponentAdapter {
 
 	    // see comment below
 	    try {
-		canvas.newSize = canvas.getSize();
+	    Dimension size = canvas.getSize();
+		canvas.newSize = new Dimension((int)(size.getWidth()*canvas.xscale), (int)(size.getHeight()*canvas.yscale));
 		canvas.newPosition = canvas.getLocationOnScreen();
 	    } catch (IllegalComponentStateException ex) {}
 
@@ -90,7 +92,8 @@ class CanvasViewEventCatcher extends ComponentAdapter {
 	// first, then canvas lock in removeComponentListener()
 
 	try {
-	    canvas.newSize = canvas.getSize();
+		Dimension size = canvas.getSize();
+		canvas.newSize = new Dimension((int)(size.getWidth()*canvas.xscale), (int)(size.getHeight()*canvas.yscale));
 	    canvas.newPosition = canvas.getLocationOnScreen();
 	} catch (IllegalComponentStateException ex) {}
 


### PR DESCRIPTION
This fixes the issue where the window is too small in java 1.10 on a hidpi system (in my case a dell xps 15).
Apologies for the import changes ... the IDE did that and I didn't notice.

The way hidpi works is that the graphics passed into paint is scaled. So on my system a window which is 200 pixels by 200 pixels has a size of 100x100 in the component and the paint is passed a graphic with a scale of 2. The original Canvas3D code ignored this and thus created a 3D view 100x100 pixels rather than the correct 200x200 pixels.