### PR TITLE
JoglPipeline.textureFillBackground did not restore depth mask gl state

### DIFF
--- a/src/javax/media/j3d/GraphicsContext3D.java
+++ b/src/javax/media/j3d/GraphicsContext3D.java
@@ -1731,6 +1731,9 @@ public int numSounds() {
                             return;
                         }
 
+                        // createNewContext finishes with a release, re-make current so the init calls below work
+                        canvas3d.makeCtxCurrent();
+
                         canvas3d.ctxTimeStamp =
                                 VirtualUniverse.mc.getContextTimeStamp();
                         canvas3d.screen.renderer.listOfCtxs.add(canvas3d.ctx);

--- a/src/javax/media/j3d/JoglPipeline.java
+++ b/src/javax/media/j3d/JoglPipeline.java
@@ -6540,20 +6540,19 @@ class JoglPipeline extends Pipeline {
     		glDrawable.setRealized(false);
     	}
         else {
-
-        	// TODO can't find an implementation which avoids the use of QueryCanvas
-        	// JOGL requires a visible Frame for an onscreen context
-
-        Frame f = new Frame();
-        f.setUndecorated(true);
-        f.setLayout(new BorderLayout());
-
         ContextQuerier querier = new ContextQuerier(cv);
 
 		    AWTGraphicsConfiguration awtConfig =
 		    		(AWTGraphicsConfiguration)Canvas3D.graphicsConfigTable.get(cv.graphicsConfiguration).getPrivateData();
 
 		    QueryCanvas canvas = new QueryCanvas(awtConfig, querier);
+
+        	// TODO can't find an implementation which avoids the use of QueryCanvas
+        	// JOGL requires a visible Frame for an onscreen context
+
+        Frame f = new Frame(canvas.getGraphicsConfiguration());
+        f.setUndecorated(true);
+        f.setLayout(new BorderLayout());
 
         f.add(canvas, BorderLayout.CENTER);
         f.setSize(MIN_FRAME_SIZE, MIN_FRAME_SIZE);

--- a/src/javax/media/j3d/Renderer.java
+++ b/src/javax/media/j3d/Renderer.java
@@ -620,6 +620,63 @@ ArrayList<TextureRetained> textureIDResourceTable = new ArrayList<TextureRetaine
                     if (canvas.isFatalError()) {
                         continue;
                     }
+                    
+                    if (canvas.ctx == null) {
+                        synchronized (VirtualUniverse.mc.contextCreationLock) {
+                        	canvas.ctx = canvas.createNewContext(null, false);                            
+                                                        
+                            if (canvas.ctx == null) {
+                				canvas.drawingSurfaceObject.unLock();
+                                // Issue 260 : indicate fatal error and notify error listeners
+                                canvas.setFatalError();
+                                RenderingError err =
+                                        new RenderingError(RenderingError.CONTEXT_CREATION_ERROR,
+                                            J3dI18N.getString("Renderer7"));
+                                err.setCanvas3D(canvas);
+                                err.setGraphicsDevice(canvas.graphicsConfiguration.getDevice());
+                                notifyErrorListeners(err);
+
+                                break doneRender;
+                			}
+                            // createNewContext finishes with a release, re-make current so the init calls below work
+                            canvas.makeCtxCurrent();
+                            
+                            if (canvas.graphics2D != null) {
+                            	canvas.graphics2D.init();
+                            }
+                            
+                            canvas.ctxTimeStamp = VirtualUniverse.mc.getContextTimeStamp();
+                            canvas.screen.renderer.listOfCtxs.add(canvas.ctx);
+                            canvas.screen.renderer.listOfCanvases.add(canvas);
+
+                            // enable separate specular color
+                            canvas.enableSeparateSpecularColor();
+                        }
+
+                        // create the cache texture state in canvas
+                        // for state download checking purpose
+                        if (canvas.texUnitState == null) {
+                        	canvas.createTexUnitState();
+                        }
+
+                        canvas.drawingSurfaceObject.contextValidated();
+                        canvas.screen.renderer.currentCtx = canvas.ctx;
+                        canvas.screen.renderer.currentDrawable = canvas.drawable;
+                        canvas.graphicsContext3D.initializeState();
+                        canvas.ctxChanged = true;
+                        canvas.canvasDirty = 0xffff;
+                        // Update Appearance
+                        canvas.graphicsContext3D.updateState(canvas.view.renderBin, RenderMolecule.SURFACE);
+
+
+                        canvas.currentLights = new LightRetained[canvas.getNumCtxLights(canvas.ctx)];
+
+                        for (j=0; j<canvas.currentLights.length; j++) {
+                        	canvas.currentLights[j] = null;
+                        }
+                    }
+                    
+                    canvas.makeCtxCurrent();
 
                   try {
 
@@ -757,6 +814,7 @@ ArrayList<TextureRetained> textureIDResourceTable = new ArrayList<TextureRetaine
                   }
 
 		    m[nmesg++].decRefcount();
+		    canvas.releaseCtx();
 		} else { // retained mode rendering
                     long startRenderTime = 0L;
                     if (MasterControl.isStatsLoggable(Level.INFO)) {


### PR DESCRIPTION
JoglPipeline.textureFillBackground did not restore depth mask gl state

This pull fixes that.
It causes immediate mode rendering to have corrupted depth masks on 2 successive render calls. 

Note I've dropped a previous use/release context commit on this pull as it was unlikely to be useful on this version.